### PR TITLE
adding penpot-mcp docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,83 @@
+# ─── Stage 1: Build ───────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Copy package manifests first to maximise layer-cache reuse
+COPY package.json package-lock.json ./
+COPY common/package.json common/package-lock.json ./common/
+COPY mcp-server/package.json mcp-server/package-lock.json ./mcp-server/
+COPY penpot-plugin/package.json penpot-plugin/package-lock.json ./penpot-plugin/
+
+# Install dependencies for every component
+RUN npm ci && \
+    npm --prefix common install && \
+    npm --prefix mcp-server install && \
+    npm --prefix penpot-plugin install
+
+# Copy all source files
+COPY common/    ./common/
+COPY mcp-server/ ./mcp-server/
+COPY penpot-plugin/ ./penpot-plugin/
+
+# 1. Build shared types (required by both server and plugin)
+RUN npm --prefix common run build
+
+# 2. Build MCP server (bundles common; external deps stay in node_modules)
+RUN npm --prefix mcp-server run build
+
+# 3. Build plugin – the WebSocket URL is baked into the JS bundle at this step.
+#    Override PENPOT_MCP_SERVER_ADDRESS via --build-arg when the server is NOT
+#    on localhost (e.g. remote deployment).
+ARG PENPOT_MCP_SERVER_ADDRESS=localhost
+ARG PENPOT_MCP_WEBSOCKET_PORT=4402
+ENV PENPOT_MCP_SERVER_ADDRESS=${PENPOT_MCP_SERVER_ADDRESS}
+ENV PENPOT_MCP_WEBSOCKET_PORT=${PENPOT_MCP_WEBSOCKET_PORT}
+RUN npm --prefix penpot-plugin run build
+
+
+# ─── Stage 2: Runtime ─────────────────────────────────────────────────────────
+FROM node:22-alpine AS runtime
+
+WORKDIR /app
+
+# Root package (provides concurrently + resolves "penpot-mcp: file:.." symlinks)
+COPY --from=builder /app/node_modules  ./node_modules
+COPY --from=builder /app/package.json  ./
+
+# common dist (resolves "@penpot-mcp/common: file:../common" symlinks in
+# mcp-server and penpot-plugin node_modules at runtime)
+COPY --from=builder /app/common/dist        ./common/dist
+COPY --from=builder /app/common/package.json ./common/
+
+# MCP server – bundled binary, static assets, YAML data files, runtime deps
+COPY --from=builder /app/mcp-server/dist         ./mcp-server/dist
+COPY --from=builder /app/mcp-server/data         ./mcp-server/data
+COPY --from=builder /app/mcp-server/node_modules ./mcp-server/node_modules
+COPY --from=builder /app/mcp-server/package.json ./mcp-server/
+
+# Plugin – pre-built static files served by `vite preview`;
+# vite is a devDep but is needed here to run the preview server
+COPY --from=builder /app/penpot-plugin/dist         ./penpot-plugin/dist
+COPY --from=builder /app/penpot-plugin/node_modules ./penpot-plugin/node_modules
+COPY --from=builder /app/penpot-plugin/package.json ./penpot-plugin/
+COPY --from=builder /app/penpot-plugin/vite.config.ts ./penpot-plugin/
+
+# Bind all servers to every interface so Docker port-mapping works
+ENV PENPOT_MCP_SERVER_LISTEN_ADDRESS=0.0.0.0
+
+# 4400 – Plugin static-file server (Vite preview)
+# 4401 – MCP server HTTP / Streamable-HTTP + SSE
+# 4402 – WebSocket  (Penpot plugin <-> MCP server)
+# 4403 – REPL       (development / debugging)
+EXPOSE 4400 4401 4402 4403
+
+# Use concurrently (already in node_modules) to run both services.
+# vite preview reads vite.config.ts from --root and serves penpot-plugin/dist/.
+# --host 0.0.0.0 overrides the default localhost binding.
+CMD ["node_modules/.bin/concurrently", \
+     "--names", "MCP-SERVER,PLUGIN-SERVER", \
+     "--prefix-colors", "cyan,magenta", \
+     "--kill-others-on-fail", \
+     "cd /app/mcp-server && node dist/index.js", \
+     "cd /app/penpot-plugin && ./node_modules/.bin/vite preview --host 0.0.0.0 --port 4400"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+IMAGE_NAME  ?= penpot-mcp
+IMAGE_TAG   ?= latest
+
+# WebSocket URL baked into the plugin bundle at build time.
+# Override for remote deployments: make build PENPOT_MCP_SERVER_ADDRESS=myserver.example.com
+PENPOT_MCP_SERVER_ADDRESS   ?= localhost
+PENPOT_MCP_WEBSOCKET_PORT   ?= 4402
+
+.PHONY: build up down logs ps clean
+
+## Build the Docker image
+build:
+	docker build \
+		--build-arg PENPOT_MCP_SERVER_ADDRESS=$(PENPOT_MCP_SERVER_ADDRESS) \
+		--build-arg PENPOT_MCP_WEBSOCKET_PORT=$(PENPOT_MCP_WEBSOCKET_PORT) \
+		-t $(IMAGE_NAME):$(IMAGE_TAG) \
+		.
+
+## Start services with docker compose (builds image if needed)
+up:
+	docker compose up -d
+
+## Stop and remove containers
+down:
+	docker compose down
+
+## Follow live logs
+logs:
+	docker compose logs -f
+
+## Show running containers
+ps:
+	docker compose ps
+
+## Remove containers, volumes, and the local image
+clean:
+	docker compose down -v
+	docker rmi $(IMAGE_NAME):$(IMAGE_TAG) 2>/dev/null || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  penpot-mcp:
+    build:
+      context: .
+      # These build-args control the WebSocket URL baked into the plugin bundle.
+      # For local use the defaults (localhost) are correct.
+      # For a remote deployment, override PENPOT_MCP_SERVER_ADDRESS with your
+      # server's public hostname or IP address and rebuild the image.
+      args:
+        PENPOT_MCP_SERVER_ADDRESS: ${PENPOT_MCP_SERVER_ADDRESS:-localhost}
+        PENPOT_MCP_WEBSOCKET_PORT: ${PENPOT_MCP_WEBSOCKET_PORT:-4402}
+    image: penpot-mcp:latest
+    ports:
+      - "${PLUGIN_SERVER_PORT:-4400}:4400"   # Plugin static-file server
+      - "${MCP_SERVER_PORT:-4401}:4401"      # MCP HTTP / SSE endpoint
+      - "${WEBSOCKET_PORT:-4402}:4402"       # WebSocket (plugin <-> server)
+      - "${REPL_PORT:-4403}:4403"            # REPL (debug)
+    environment:
+      # Bind everything inside the container to all interfaces
+      PENPOT_MCP_SERVER_LISTEN_ADDRESS: "0.0.0.0"
+      PENPOT_MCP_SERVER_PORT: "4401"
+      PENPOT_MCP_WEBSOCKET_PORT: "4402"
+      PENPOT_MCP_REPL_PORT: "4403"
+      # Allow the plugin preview server to serve requests from any host header.
+      # Set to a comma-separated list of hostnames to restrict access.
+      PENPOT_MCP_PLUGIN_SERVER_LISTEN_ADDRESS: ${PENPOT_MCP_PLUGIN_SERVER_LISTEN_ADDRESS:-}
+      # Log level: trace | debug | info | warn | error
+      PENPOT_MCP_LOG_LEVEL: ${PENPOT_MCP_LOG_LEVEL:-info}
+      # Remote mode disables local file-system access (set true for remote deployments)
+      PENPOT_MCP_REMOTE_MODE: ${PENPOT_MCP_REMOTE_MODE:-false}
+    restart: unless-stopped
+    # Persist log files across container restarts
+    volumes:
+      - penpot-mcp-logs:/app/mcp-server/logs
+
+volumes:
+  penpot-mcp-logs:


### PR DESCRIPTION
# Overview
Adds Docker support for running the full penpot-mcp stack (MCP server + Penpot plugin) as a containerized service.
## Changes
### Dockerfile — Multi-stage build:
- Stage 1 (builder): Uses node:22-alpine to install dependencies and build all three components in order: common (shared types) → mcp-server → penpot-plugin. The WebSocket server address is baked into the plugin bundle at build time via --build-arg.
- Stage 2 (runtime): Copies only compiled artifacts and required runtime files, keeping the image lean. Exposes ports 4400 (plugin static server), 4401 (MCP HTTP/SSE), 4402 (WebSocket), and 4403 (REPL). Runs both services concurrently using concurrently.
### docker-compose.yml — Defines the penpot-mcp service with:
- Configurable port mappings and environment variables via .env or shell overrides.
- A named volume (penpot-mcp-logs) to persist logs across container restarts.
- restart: unless-stopped for production reliability.
### Makefile — Convenience targets for common Docker workflows:
- make build — Build the image (supports PENPOT_MCP_SERVER_ADDRESS override for remote deployments).
- make up / make down — Start/stop the stack.
- make logs / make ps — Inspect running services.
- make clean — Tear down containers, volumes, and the local image.