### PR TITLE
feat: add create_frame tool as convenience alias for penpot.createBoard()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
+> [!IMPORTANT]
+> This repository has been archived on 2026-02-03.  
+> Its contents have been fully integrated into the main Penpot repository:
+> https://github.com/penpot/penpot/tree/develop/mcp
+
 ![mcp-server-cover-github-1](https://github.com/user-attachments/assets/dcd14e63-fecd-424f-9a50-c1b1eafe2a4f)
 
 # Penpot's Official MCP Server
-
-**IMPORTANT:** This repository is archived. Its contents and
-development have been fully integrated into the main Penpot project:
-https://github.com/penpot/penpot
-
 
 Penpot integrates a LLM layer built on the Model Context Protocol (MCP) via Penpot's Plugin API to interact with a Penpot design file. Penpot's MCP server enables LLMs to perfom data queries, transformation and creation operations.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 # Penpot's Official MCP Server
 
+**IMPORTANT:** This repository is archived. Its contents and
+development have been fully integrated into the main Penpot project:
+https://github.com/penpot/penpot
+
+
 Penpot integrates a LLM layer built on the Model Context Protocol (MCP) via Penpot's Plugin API to interact with a Penpot design file. Penpot's MCP server enables LLMs to perfom data queries, transformation and creation operations.
 
 Penpot's MCP Server is unlike any other you've seen. You get design-to- design, code-to-design and design-code supercharged workflows.

--- a/mcp-server/data/prompts.yml
+++ b/mcp-server/data/prompts.yml
@@ -88,11 +88,10 @@ initial_instructions: |
   Boards can have layout systems that automatically control the positioning and spacing of their children:
 
     * **Flex Layout**: A flexbox-style layout system
-      - Add to a board with `board.addFlexLayout(): FlexLayout`; instance then accessibly via `board.flex`;
-        Check with: `if (board.flex) { ... }`
       - Properties: `dir`, `rowGap`, `columnGap`, `alignItems`, `justifyContent`;
          - `dir`: "row" | "column" | "row-reverse" | "column-reverse"
-      - Padding: `topPadding`, `rightPadding`, `bottomPadding`, `leftPadding`, or combined `verticalPadding`, `horizontalPadding`
+         - Padding: `topPadding`, `rightPadding`, `bottomPadding`, `leftPadding`, or combined `verticalPadding`, `horizontalPadding`
+         - To modify spacing: adjust `rowGap` and `columnGap` properties, not individual child positions
       - When a board has flex layout, 
          - child positions are controlled by the layout system, not by individual x/y coordinates;
            appending or inserting children automatically positions them according to the layout rules.
@@ -104,10 +103,14 @@ initial_instructions: |
         of the `children` array for dir="column" or dir="row", which is what you want. So call it in the order of visual appearance.
         To insert at a specific index, use `board.insertChild(index, shape)`, bearing in mind the reversed order for dir="column" 
         or dir="row".
-      - To modify spacing: adjust `rowGap` and `columnGap` properties, not individual child positions
+      - Add to a board with `board.addFlexLayout(): FlexLayout`; instance then accessible via `board.flex`.
+        IMPORTANT: When adding a flex layout to a container that already has children, 
+        use `penpotUtils.addFlexLayout(container, dir)` instead! This preserves the existing visual order of children.
+        Otherwise, children will be arbitrarily reordered when the children order suddenly determines the display order. 
+      - Check with: `if (board.flex) { ... }`
     
     * **Grid Layout**: A CSS grid-style layout system
-      - Add to a board with `board.addFlexLayout(): FlexLayout`; instance then accessibly via `board.grid`;
+      - Add to a board with `board.addGridLayout(): GridLayout`; instance then accessibly via `board.grid`;
         Check with: `if (board.grid) { ... }`
       - Properties: `rows`, `columns`, `rowGap`, `columnGap`
       - Children are positioned via 1-based row/column indices

--- a/mcp-server/data/prompts.yml
+++ b/mcp-server/data/prompts.yml
@@ -87,13 +87,22 @@ initial_instructions: |
 
   Boards can have layout systems that automatically control the positioning and spacing of their children:
 
+    * If a board has a layout system, then child positions are controlled by the layout system.
+      For every child, key properties of the child within the layout are stored in `child.layoutChild: LayoutChildProperties`:
+      - `absolute: boolean` - if true, child position is not controlled by layout system. x/y will set *relative* position within parent!
+      - margins (`topMargin`, `rightMargin`, `bottomMargin`, `leftMargin` or combined `verticalMargin`, `horizontalMargin`)
+      - sizing (`verticalSizing`, `horizontalSizing`: "fill" | "auto" | "fix")
+      - min/max sizes (`minWidth`, `maxWidth`, `minHeight`, `maxHeight`)
+      - `zIndex: number` (higher numbers on top)
+      
     * **Flex Layout**: A flexbox-style layout system
       - Properties: `dir`, `rowGap`, `columnGap`, `alignItems`, `justifyContent`;
          - `dir`: "row" | "column" | "row-reverse" | "column-reverse"
          - Padding: `topPadding`, `rightPadding`, `bottomPadding`, `leftPadding`, or combined `verticalPadding`, `horizontalPadding`
-         - To modify spacing: adjust `rowGap` and `columnGap` properties, not individual child positions
+         - To modify spacing: adjust `rowGap` and `columnGap` properties, not individual child positions.
+           Optionally, adjust indivudual child margins via `child.layoutChild`.
       - When a board has flex layout, 
-         - child positions are controlled by the layout system, not by individual x/y coordinates;
+         - child positions are controlled by the layout system, not by individual x/y coordinates (unless `child.layoutChild.absolute` is true);
            appending or inserting children automatically positions them according to the layout rules.
          - CRITICAL: For for dir="column" or dir="row", the order of the `children` array is reversed relative to the visual order!
            Therefore, the element that appears first in the array, appears visually at the end (bottom/right) and vice versa.

--- a/mcp-server/data/prompts.yml
+++ b/mcp-server/data/prompts.yml
@@ -220,6 +220,8 @@ initial_instructions: |
   * When dealing with containment issues, ask: Is the parent too small OR is the child too large?
     Container sizes are usually intentional, check content first.
   * Check for reasonable font sizes and typefaces
+  * The use of flex layouts is encouraged for cases where elements are arranged in rows or columns with consistent spacing/positioning.
+    Consider converting boards to flex layout when appropriate.
 
   # Asset Libraries
     

--- a/mcp-server/src/PenpotMcpServer.ts
+++ b/mcp-server/src/PenpotMcpServer.ts
@@ -11,6 +11,7 @@ import { HighLevelOverviewTool } from "./tools/HighLevelOverviewTool";
 import { PenpotApiInfoTool } from "./tools/PenpotApiInfoTool";
 import { ExportShapeTool } from "./tools/ExportShapeTool";
 import { ImportImageTool } from "./tools/ImportImageTool";
+import { CreateFrameTool } from "./tools/CreateFrameTool";
 import { ReplServer } from "./ReplServer";
 import { ApiDocs } from "./ApiDocs";
 
@@ -131,6 +132,7 @@ export class PenpotMcpServer {
             new HighLevelOverviewTool(this),
             new PenpotApiInfoTool(this, this.apiDocs),
             new ExportShapeTool(this), // tool adapts to file system access internally
+            new CreateFrameTool(this),
         ];
         if (this.isFileSystemAccessEnabled()) {
             toolInstances.push(new ImportImageTool(this));

--- a/mcp-server/src/static/repl.html
+++ b/mcp-server/src/static/repl.html
@@ -6,18 +6,21 @@
         <title>Penpot API REPL</title>
         <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
         <style>
+            html,
             body {
-                font-family: "Consolas", "Monaco", "Lucida Console", monospace;
-                max-width: 1200px;
-                margin: 0 auto;
-                padding: 20px;
-                background-color: #f5f5f5;
+                height: 100%;
+                margin: 0;
+                padding: 0;
+                overflow: hidden;
             }
 
-            h1 {
-                color: #333;
-                text-align: center;
-                margin-bottom: 30px;
+            body {
+                font-family: "Consolas", "Monaco", "Lucida Console", monospace;
+                background-color: #f5f5f5;
+                display: flex;
+                flex-direction: column;
+                padding: 15px;
+                box-sizing: border-box;
             }
 
             .repl-container {
@@ -25,9 +28,12 @@
                 border: 1px solid #ddd;
                 border-radius: 4px;
                 padding: 15px;
-                min-height: 400px;
-                max-height: 80vh;
+                flex: 1;
                 overflow-y: auto;
+                max-width: 1200px;
+                width: 100%;
+                margin: 0 auto;
+                box-sizing: border-box;
             }
 
             .repl-entry {
@@ -55,7 +61,7 @@
 
             .code-input {
                 width: 100%;
-                min-height: 60px;
+                min-height: 80px;
                 font-family: "Consolas", "Monaco", "Lucida Console", monospace;
                 font-size: 14px;
                 border: 1px solid #ddd;
@@ -159,8 +165,9 @@
                 text-align: center;
                 color: #666;
                 font-size: 12px;
-                margin-top: 15px;
+                padding: 10px 0;
                 font-style: italic;
+                flex-shrink: 0;
             }
 
             .entry-number {
@@ -168,37 +175,52 @@
                 font-size: 12px;
                 margin-bottom: 5px;
             }
+
+            .history-indicator {
+                background-color: #fff3cd;
+                border: 1px solid #ffc107;
+                border-radius: 4px;
+                padding: 4px 10px;
+                font-size: 12px;
+                color: #856404;
+                display: inline-block;
+                margin-bottom: 8px;
+            }
         </style>
     </head>
     <body>
-        <h1>Penpot API REPL</h1>
-
         <div class="repl-container" id="repl-container">
             <!-- REPL entries will be dynamically added here -->
         </div>
 
-        <div class="controls-hint">Press Ctrl+Enter to execute code • Shift+Enter for new line</div>
+        <div class="controls-hint">Ctrl+Enter to execute • Arrow up/down for command history</div>
 
         <script>
             $(document).ready(function () {
                 let isExecuting = false;
                 let entryCounter = 1;
-                let lastCode = ""; // store the last executed code
+                let commandHistory = []; // full history of executed commands
+                let historyIndex = 0; // current position in history
+                let isBrowsingHistory = false; // whether we are currently browsing history
+                let tempInput = ""; // temporary storage for current input when browsing history
 
                 // create the initial input entry
                 createNewEntry();
 
                 function createNewEntry() {
                     const entryId = `entry-${entryCounter}`;
-                    const defaultCode = lastCode || "";
+                    const isFirstEntry = entryCounter === 1;
+                    const placeholder = isFirstEntry
+                        ? `// Enter your JavaScript code here...
+console.log('Hello from Penpot!');
+return 'This will be the result';`
+                        : "";
                     const entryHtml = `
                         <div class="repl-entry" id="${entryId}">
                             <div class="entry-number">In [${entryCounter}]:</div>
                             <div class="input-section">
                                 <textarea class="code-input" id="code-input-${entryCounter}"
-                                         placeholder="// Enter your JavaScript code here...
-console.log('Hello from Penpot!');
-return 'This will be the result';">${escapeHtml(defaultCode)}</textarea>
+                                         placeholder="${placeholder}"></textarea>
                                 <button class="execute-btn" id="execute-btn-${entryCounter}">Execute Code</button>
                             </div>
                         </div>
@@ -209,16 +231,161 @@ return 'This will be the result';">${escapeHtml(defaultCode)}</textarea>
                     // bind events for this entry
                     bindEntryEvents(entryCounter);
 
-                    // focus on the new input
-                    $(`#code-input-${entryCounter}`).focus();
+                    // focus on the new input without scrolling
+                    const $input = $(`#code-input-${entryCounter}`);
+                    $input[0].focus({ preventScroll: true });
 
-                    // auto-resize textarea
-                    $(`#code-input-${entryCounter}`).on("input", function () {
-                        this.style.height = "auto";
-                        this.style.height = Math.max(60, this.scrollHeight) + "px";
+                    // auto-resize textarea on input
+                    $input.on("input", function () {
+                        autoResizeTextarea(this);
                     });
 
                     entryCounter++;
+                }
+
+                /**
+                 * Resizes a textarea to fit its content, with a minimum height.
+                 * Adds border height since scrollHeight excludes borders but box-sizing: border-box includes them.
+                 */
+                function autoResizeTextarea(textarea) {
+                    textarea.style.height = "auto";
+                    // add 2px for top and bottom border (1px each)
+                    textarea.style.height = Math.max(80, textarea.scrollHeight + 2) + "px";
+                }
+
+                /**
+                 * Checks if the cursor is at the beginning of a textarea (position 0 with no selection).
+                 */
+                function isCursorAtBeginning(textarea) {
+                    return textarea.selectionStart === 0 && textarea.selectionEnd === 0;
+                }
+
+                /**
+                 * Checks if the cursor is at the end of a textarea (position at text length with no selection).
+                 */
+                function isCursorAtEnd(textarea) {
+                    const len = textarea.value.length;
+                    return textarea.selectionStart === len && textarea.selectionEnd === len;
+                }
+
+                /**
+                 * Navigates through command history for the given entry's textarea.
+                 * @param direction -1 for previous (up), +1 for next (down)
+                 * @param entryNum the entry number
+                 */
+                function navigateHistory(direction, entryNum) {
+                    const $codeInput = $(`#code-input-${entryNum}`);
+                    const textarea = $codeInput[0];
+
+                    if (commandHistory.length === 0) return;
+
+                    if (direction === -1) {
+                        // going back in history (arrow up)
+                        if (!isBrowsingHistory) {
+                            // starting to browse history: save current input
+                            tempInput = $codeInput.val();
+                            isBrowsingHistory = true;
+                            historyIndex = commandHistory.length - 1;
+                        } else if (historyIndex > 0) {
+                            // go further back in history
+                            historyIndex--;
+                        } else {
+                            // already at oldest entry, do nothing
+                            return;
+                        }
+                        $codeInput.val(commandHistory[historyIndex]);
+                        autoResizeTextarea(textarea);
+                        // keep cursor at beginning for continued history navigation
+                        textarea.setSelectionRange(0, 0);
+                        // show history position (1 = most recent)
+                        const position = commandHistory.length - historyIndex;
+                        showHistoryIndicator(entryNum, position, commandHistory.length);
+                    } else {
+                        // going forward in history (arrow down)
+                        if (!isBrowsingHistory) {
+                            // not browsing history, do nothing
+                            return;
+                        } else if (historyIndex >= commandHistory.length - 1) {
+                            // at most recent entry, return to original input
+                            isBrowsingHistory = false;
+                            $codeInput.val(tempInput);
+                            autoResizeTextarea(textarea);
+                            // cursor at beginning (same as when we entered history)
+                            textarea.setSelectionRange(0, 0);
+                            hideHistoryIndicator();
+                        } else {
+                            // go forward in history
+                            historyIndex++;
+                            $codeInput.val(commandHistory[historyIndex]);
+                            autoResizeTextarea(textarea);
+                            // keep cursor at beginning
+                            textarea.setSelectionRange(0, 0);
+                            // update history position indicator
+                            const position = commandHistory.length - historyIndex;
+                            showHistoryIndicator(entryNum, position, commandHistory.length);
+                        }
+                    }
+                }
+
+                /**
+                 * Exits history browsing mode, keeping current content in the input.
+                 * Moves cursor to end of input.
+                 * @param entryNum the entry number (optional, cursor not moved if not provided)
+                 */
+                function exitHistoryBrowsing(entryNum) {
+                    if (isBrowsingHistory) {
+                        isBrowsingHistory = false;
+                        hideHistoryIndicator();
+                        if (entryNum !== undefined) {
+                            const textarea = $(`#code-input-${entryNum}`)[0];
+                            const len = textarea.value.length;
+                            textarea.setSelectionRange(len, len);
+                        }
+                    }
+                }
+
+                /**
+                 * Scrolls the repl container to show the output section of the given entry.
+                 */
+                function scrollToOutput($entry) {
+                    const $container = $("#repl-container");
+                    const $outputSection = $entry.find(".output-section");
+                    if ($outputSection.length) {
+                        const containerTop = $container.offset().top;
+                        const outputTop = $outputSection.offset().top;
+                        const scrollTop = $container.scrollTop();
+                        $container.animate(
+                            {
+                                scrollTop: scrollTop + (outputTop - containerTop),
+                            },
+                            300
+                        );
+                    }
+                }
+
+                /**
+                 * Shows or updates the history indicator for the current entry.
+                 * @param entryNum the entry number
+                 * @param position 1-based position from most recent (1 = most recent)
+                 * @param total total number of history items
+                 */
+                function showHistoryIndicator(entryNum, position, total) {
+                    const $entry = $(`#entry-${entryNum}`);
+                    let $indicator = $entry.find(".history-indicator");
+
+                    if ($indicator.length === 0) {
+                        $entry.find(".input-section").before('<div class="history-indicator"></div>');
+                        $indicator = $entry.find(".history-indicator");
+                    }
+
+                    $indicator.text(`History item ${position}/${total}`);
+                }
+
+                /**
+                 * Hides the history indicator.
+                 */
+                function hideHistoryIndicator() {
+                    $(".history-indicator").remove();
                 }
 
                 function bindEntryEvents(entryNum) {
@@ -228,11 +395,36 @@ return 'This will be the result';">${escapeHtml(defaultCode)}</textarea>
                     // bind execute button click
                     $executeBtn.on("click", () => executeCode(entryNum));
 
-                    // bind Ctrl+Enter keyboard shortcut
+                    // bind keyboard shortcuts
                     $codeInput.on("keydown", function (e) {
+                        // Ctrl+Enter to execute
                         if (e.ctrlKey && e.key === "Enter") {
                             e.preventDefault();
+                            exitHistoryBrowsing(entryNum);
                             executeCode(entryNum);
+                            return;
+                        }
+
+                        // arrow up at beginning of input (or while browsing history): navigate to previous history entry
+                        if (e.key === "ArrowUp" && (isBrowsingHistory || isCursorAtBeginning(this))) {
+                            e.preventDefault();
+                            navigateHistory(-1, entryNum);
+                            return;
+                        }
+
+                        // arrow down at end of input (or while browsing history): navigate to next history entry
+                        if (e.key === "ArrowDown" && (isBrowsingHistory || isCursorAtEnd(this))) {
+                            e.preventDefault();
+                            navigateHistory(+1, entryNum);
+                            return;
+                        }
+
+                        // any key except pure modifier keys exits history browsing
+                        if (isBrowsingHistory) {
+                            const isModifierOnly = ["Shift", "Control", "Alt", "Meta"].includes(e.key);
+                            if (!isModifierOnly) {
+                                exitHistoryBrowsing();
+                            }
                         }
                     });
                 }
@@ -328,15 +520,16 @@ return 'This will be the result';">${escapeHtml(defaultCode)}</textarea>
                             $codeInput.prop("readonly", true);
                             $(`#execute-btn-${entryNum}`).remove();
 
-                            // store the code for the next entry
-                            lastCode = code;
+                            // store the code in history
+                            commandHistory.push(code);
+                            isBrowsingHistory = false; // reset history navigation
+                            tempInput = ""; // clear temporary input
 
                             // create a new entry for the next input
                             createNewEntry();
 
-                            // scroll to the new entry
-                            const $container = $("#repl-container");
-                            $container.scrollTop($container[0].scrollHeight);
+                            // scroll to the output section of the executed entry
+                            scrollToOutput($entry);
                         },
                         error: function (xhr) {
                             let errorData;
@@ -346,6 +539,9 @@ return 'This will be the result';">${escapeHtml(defaultCode)}</textarea>
                                 errorData = { error: "Network error or invalid response" };
                             }
                             displayResult(entryNum, errorData, true);
+
+                            // scroll to the error output
+                            scrollToOutput($entry);
                         },
                         complete: function () {
                             setExecuting(entryNum, false);

--- a/mcp-server/src/tools/CreateFrameTool.ts
+++ b/mcp-server/src/tools/CreateFrameTool.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+import { Tool } from "../Tool";
+import type { ToolResponse } from "../ToolResponse";
+import { TextResponse } from "../ToolResponse";
+import "reflect-metadata";
+import { PenpotMcpServer } from "../PenpotMcpServer";
+import { ExecuteCodePluginTask } from "../tasks/ExecuteCodePluginTask";
+
+/**
+ * Arguments class for CreateFrameTool
+ */
+export class CreateFrameArgs {
+    static schema = {
+        name: z
+            .string()
+            .optional()
+            .describe("Name for the frame. Defaults to 'Frame' if not provided."),
+        x: z
+            .number()
+            .optional()
+            .describe("X position of the frame on the canvas. Defaults to 0."),
+        y: z
+            .number()
+            .optional()
+            .describe("Y position of the frame on the canvas. Defaults to 0."),
+        width: z
+            .number()
+            .optional()
+            .describe("Width of the frame in pixels. Defaults to 100."),
+        height: z
+            .number()
+            .optional()
+            .describe("Height of the frame in pixels. Defaults to 100."),
+    };
+
+    name?: string;
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+}
+
+/**
+ * Tool for creating a frame (board) in Penpot.
+ *
+ * Note: The Penpot Plugin API uses `penpot.createBoard()` to create frames.
+ * The term "board" is Penpot's internal name for what is displayed as a "frame"
+ * in the UI and referred to as a frame in design tool conventions.
+ * This tool provides a `create_frame` name to match that convention and
+ * reduce confusion when coming from other design tools.
+ *
+ * See: https://github.com/penpot/penpot-mcp/issues/43
+ */
+export class CreateFrameTool extends Tool<CreateFrameArgs> {
+    constructor(mcpServer: PenpotMcpServer) {
+        super(mcpServer, CreateFrameArgs.schema);
+    }
+
+    public getToolName(): string {
+        return "create_frame";
+    }
+
+    public getToolDescription(): string {
+        return (
+            "Creates a frame on the current Penpot page.\n" +
+            "Frames are the primary container element in Penpot (equivalent to frames in Figma " +
+            "or artboards in other design tools).\n" +
+            "Note: The Penpot Plugin API exposes frames as 'boards' (`penpot.createBoard()`). " +
+            "This tool wraps that API under the conventional 'frame' name.\n" +
+            "Returns the ID and properties of the created frame."
+        );
+    }
+
+    protected async executeCore(args: CreateFrameArgs): Promise<ToolResponse> {
+        const name = args.name ?? "Frame";
+        const x = args.x ?? 0;
+        const y = args.y ?? 0;
+        const width = args.width ?? 100;
+        const height = args.height ?? 100;
+
+        const code = `
+const frame = penpot.createBoard();
+frame.name = ${JSON.stringify(name)};
+frame.x = ${x};
+frame.y = ${y};
+frame.width = ${width};
+frame.height = ${height};
+penpot.currentPage.appendChild(frame);
+return { id: frame.id, name: frame.name, x: frame.x, y: frame.y, width: frame.width, height: frame.height };
+        `.trim();
+
+        const task = new ExecuteCodePluginTask({ code });
+        const result = await this.mcpServer.pluginBridge.executePluginTask(task);
+
+        if (result.data !== undefined) {
+            return new TextResponse(JSON.stringify(result.data, null, 2));
+        } else {
+            return new TextResponse("Frame created successfully.");
+        }
+    }
+}

--- a/penpot-plugin/index.html
+++ b/penpot-plugin/index.html
@@ -6,6 +6,12 @@
         <title>Penpot plugin example</title>
     </head>
     <body>
+        <div style="font-weight: bold; font-size: 11px; margin-bottom: 10px">
+            IMPORTANT: You are using an outdated version of the Penpot MCP server. The MCP server has been integrated
+            into the Penpot repository. Find the latest version here:<br />
+            https://github.com/penpot/penpot/tree/develop/mcp
+        </div>
+
         <button type="button" data-appearance="secondary" data-handler="connect-mcp">Connect to MCP server</button>
 
         <div id="connection-status" style="margin-top: 10px; font-size: 12px; color: #666">Not connected</div>

--- a/penpot-plugin/src/PenpotUtils.ts
+++ b/penpot-plugin/src/PenpotUtils.ts
@@ -1,4 +1,4 @@
-import { Fill, FlexLayout, GridLayout, Page, Rectangle, Shape } from "@penpot/plugin-types";
+import { Board, Fill, FlexLayout, GridLayout, Page, Rectangle, Shape } from "@penpot/plugin-types";
 
 export class PenpotUtils {
     /**
@@ -196,6 +196,37 @@ export class PenpotUtils {
         }
         shape.x = shape.parent.x + parentX;
         shape.y = shape.parent.y + parentY;
+    }
+
+    /**
+     * Adds a flex layout to a container while preserving the visual order of existing children.
+     * Without this, adding a flex layout can arbitrarily reorder children.
+     *
+     * The method sorts children by their current position (x for "row", y for "column") before
+     * adding the layout, then reorders them to maintain that visual sequence.
+     *
+     * @param container - The container (board) to add the flex layout to
+     * @param dir - The layout direction: "row" for horizontal, "column" for vertical
+     * @returns The created FlexLayout instance
+     */
+    public static addFlexLayout(container: Board, dir: "column" | "row"): FlexLayout {
+        // obtain children sorted by position (ascending)
+        const children = "children" in container && container.children ? [...container.children] : [];
+        const sortedChildren = children.sort((a, b) => (dir === "row" ? a.x - b.x : a.y - b.y));
+
+        // add the flex layout
+        const flexLayout = container.addFlexLayout();
+        flexLayout.dir = dir;
+
+        // reorder children to preserve visual order; since the children array is reversed
+        // relative to visual order for dir="column" or dir="row", we insert each child at
+        // index 0 in sorted order, which places the first (smallest position) at the highest
+        // index, making it appear first visually
+        for (const child of sortedChildren) {
+            child.setParentIndex(0);
+        }
+
+        return flexLayout;
     }
 
     /**

--- a/penpot-plugin/src/plugin.ts
+++ b/penpot-plugin/src/plugin.ts
@@ -11,7 +11,7 @@ declare const IS_MULTI_USER_MODE: boolean;
 const isMultiUserMode = typeof IS_MULTI_USER_MODE !== "undefined" ? IS_MULTI_USER_MODE : false;
 
 // Open the plugin UI (main.ts)
-penpot.ui.open("Penpot MCP Plugin", `?theme=${penpot.theme}&multiUser=${isMultiUserMode}`, { width: 158, height: 200 });
+penpot.ui.open("Penpot MCP Plugin", `?theme=${penpot.theme}&multiUser=${isMultiUserMode}`, { width: 300, height: 250 });
 
 // Handle messages
 penpot.ui.onMessage<string | { id: string; task: string; params: any }>((message) => {

--- a/python-scripts/prepare_api_docs.py
+++ b/python-scripts/prepare_api_docs.py
@@ -15,6 +15,9 @@ from sensai.util import logging
 log = logging.getLogger(__name__)
 
 
+API_DOCS_URL = "https://doc.plugins.penpot.app"
+
+
 class PenpotAPIContentMarkdownConverter(MarkdownConverter):
     """
     Markdown converter for Penpot API docs, specifically for the .col-content element
@@ -99,6 +102,10 @@ class TypeInfo:
         if referencing_types:
             self.overview += "\n\nReferenced by: " + ", ".join(sorted(referencing_types))
 
+    def __repr__(self) -> str:
+        num_members = {k: len(v) for k, v in self.members.items()}
+        return f"TypeInfo(overview_length={len(self.overview)}, num_members={num_members})"
+
 
 class YamlConverter:
     """Converts dictionaries to YAML with all strings in block literal style"""
@@ -133,7 +140,7 @@ class YamlConverter:
 class PenpotAPIDocsProcessor:
     def __init__(self):
         self.md_converter = PenpotAPIContentMarkdownConverter()
-        self.base_url = "https://penpot-plugins-api-doc.pages.dev"
+        self.base_url = API_DOCS_URL
         self.types: dict[str, TypeInfo] = {}
         self.type_referenced_by: dict[str, set[str]] = collections.defaultdict(set)
 
@@ -153,6 +160,7 @@ class PenpotAPIDocsProcessor:
                 type_name = href.split("/")[-1].replace(".html", "")
                 log.info("Processing page: %s", type_name)
                 type_info = self.process_page(href, type_name)
+                print(f"Adding '{type_name}' with {type_info}")
                 self.types[type_name] = type_info
 
         # add type reference information
@@ -166,11 +174,11 @@ class PenpotAPIDocsProcessor:
         data_dict = {k: dataclasses.asdict(v) for k, v in self.types.items()}
         YamlConverter().to_file(data_dict, yaml_path)
 
-    def _fetch(self, rel_url: str) -> str:
+    def _fetch(self, rel_url: str) -> bytes:
         response = requests.get(f"{self.base_url}/{rel_url}")
         if response.status_code != 200:
             raise Exception(f"Failed to retrieve page: {response.status_code}")
-        html_content = response.text
+        html_content = response.content
         return html_content
 
     def _html_to_markdown(self, html_content: str) -> str:
@@ -255,5 +263,5 @@ def debug_type_conversion(rel_url: str):
 
 
 if __name__ == '__main__':
-    # debug_type_conversion("interfaces/ShapeBase")
+    # debug_type_conversion("interfaces/LayoutChildProperties")
     logging.run_main(main)


### PR DESCRIPTION
## Summary

Adds a `create_frame` MCP tool that wraps `penpot.createBoard()` under the conventional frame name.

## Context

Penpot deliberately uses the term **board** (`penpot.createBoard()`) for its primary container element — this is an intentional Penpot naming choice, not an oversight. However, users coming from Figma and other design tools expect `create_frame` as the natural name for this operation, and the mismatch creates friction when prompting AI assistants.

This tool bridges that gap without changing Penpot's underlying terminology.

## What this adds

**New tool: `create_frame`**

Parameters:
- `name` (optional) — frame name, defaults to `"Frame"`
- `x`, `y` (optional) — canvas position, defaults to `0`
- `width`, `height` (optional) — dimensions in pixels, defaults to `100`

Returns: `{ id, name, x, y, width, height }` of the created frame.

Internally calls `penpot.createBoard()` and the tool description explicitly notes the Penpot/board vs. frame naming distinction.

## Relation to issue

Closes #43

## Notes

- No changes to `execute_code` or existing tools
- Follows the same pattern as `ExportShapeTool` (generates plugin code internally)
- tsc passes clean