### PR TITLE
feat: add create_frame tool as convenience alias for penpot.createBoard()

### DIFF
--- a/mcp-server/src/PenpotMcpServer.ts
+++ b/mcp-server/src/PenpotMcpServer.ts
@@ -11,6 +11,7 @@ import { HighLevelOverviewTool } from "./tools/HighLevelOverviewTool";
 import { PenpotApiInfoTool } from "./tools/PenpotApiInfoTool";
 import { ExportShapeTool } from "./tools/ExportShapeTool";
 import { ImportImageTool } from "./tools/ImportImageTool";
+import { CreateFrameTool } from "./tools/CreateFrameTool";
 import { ReplServer } from "./ReplServer";
 import { ApiDocs } from "./ApiDocs";
 
@@ -131,6 +132,7 @@ export class PenpotMcpServer {
             new HighLevelOverviewTool(this),
             new PenpotApiInfoTool(this, this.apiDocs),
             new ExportShapeTool(this), // tool adapts to file system access internally
+            new CreateFrameTool(this),
         ];
         if (this.isFileSystemAccessEnabled()) {
             toolInstances.push(new ImportImageTool(this));

--- a/mcp-server/src/tools/CreateFrameTool.ts
+++ b/mcp-server/src/tools/CreateFrameTool.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+import { Tool } from "../Tool";
+import type { ToolResponse } from "../ToolResponse";
+import { TextResponse } from "../ToolResponse";
+import "reflect-metadata";
+import { PenpotMcpServer } from "../PenpotMcpServer";
+import { ExecuteCodePluginTask } from "../tasks/ExecuteCodePluginTask";
+
+/**
+ * Arguments class for CreateFrameTool
+ */
+export class CreateFrameArgs {
+    static schema = {
+        name: z
+            .string()
+            .optional()
+            .describe("Name for the frame. Defaults to 'Frame' if not provided."),
+        x: z
+            .number()
+            .optional()
+            .describe("X position of the frame on the canvas. Defaults to 0."),
+        y: z
+            .number()
+            .optional()
+            .describe("Y position of the frame on the canvas. Defaults to 0."),
+        width: z
+            .number()
+            .optional()
+            .describe("Width of the frame in pixels. Defaults to 100."),
+        height: z
+            .number()
+            .optional()
+            .describe("Height of the frame in pixels. Defaults to 100."),
+    };
+
+    name?: string;
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+}
+
+/**
+ * Tool for creating a frame (board) in Penpot.
+ *
+ * Note: The Penpot Plugin API uses `penpot.createBoard()` to create frames.
+ * The term "board" is Penpot's internal name for what is displayed as a "frame"
+ * in the UI and referred to as a frame in design tool conventions.
+ * This tool provides a `create_frame` name to match that convention and
+ * reduce confusion when coming from other design tools.
+ *
+ * See: https://github.com/penpot/penpot-mcp/issues/43
+ */
+export class CreateFrameTool extends Tool<CreateFrameArgs> {
+    constructor(mcpServer: PenpotMcpServer) {
+        super(mcpServer, CreateFrameArgs.schema);
+    }
+
+    public getToolName(): string {
+        return "create_frame";
+    }
+
+    public getToolDescription(): string {
+        return (
+            "Creates a frame on the current Penpot page.\n" +
+            "Frames are the primary container element in Penpot (equivalent to frames in Figma " +
+            "or artboards in other design tools).\n" +
+            "Note: The Penpot Plugin API exposes frames as 'boards' (`penpot.createBoard()`). " +
+            "This tool wraps that API under the conventional 'frame' name.\n" +
+            "Returns the ID and properties of the created frame."
+        );
+    }
+
+    protected async executeCore(args: CreateFrameArgs): Promise<ToolResponse> {
+        const name = args.name ?? "Frame";
+        const x = args.x ?? 0;
+        const y = args.y ?? 0;
+        const width = args.width ?? 100;
+        const height = args.height ?? 100;
+
+        const code = `
+const frame = penpot.createBoard();
+frame.name = ${JSON.stringify(name)};
+frame.x = ${x};
+frame.y = ${y};
+frame.width = ${width};
+frame.height = ${height};
+penpot.currentPage.appendChild(frame);
+return { id: frame.id, name: frame.name, x: frame.x, y: frame.y, width: frame.width, height: frame.height };
+        `.trim();
+
+        const task = new ExecuteCodePluginTask({ code });
+        const result = await this.mcpServer.pluginBridge.executePluginTask(task);
+
+        if (result.data !== undefined) {
+            return new TextResponse(JSON.stringify(result.data, null, 2));
+        } else {
+            return new TextResponse("Frame created successfully.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `create_frame` MCP tool that wraps `penpot.createBoard()` under the conventional frame name.

## Context

Penpot deliberately uses the term **board** (`penpot.createBoard()`) for its primary container element — this is an intentional Penpot naming choice, not an oversight. However, users coming from Figma and other design tools expect `create_frame` as the natural name for this operation, and the mismatch creates friction when prompting AI assistants.

This tool bridges that gap without changing Penpot's underlying terminology.

## What this adds

**New tool: `create_frame`**

Parameters:
- `name` (optional) — frame name, defaults to `"Frame"`
- `x`, `y` (optional) — canvas position, defaults to `0`
- `width`, `height` (optional) — dimensions in pixels, defaults to `100`

Returns: `{ id, name, x, y, width, height }` of the created frame.

Internally calls `penpot.createBoard()` and the tool description explicitly notes the Penpot/board vs. frame naming distinction.

## Relation to issue

Closes #43

## Notes

- No changes to `execute_code` or existing tools
- Follows the same pattern as `ExportShapeTool` (generates plugin code internally)
- tsc passes clean