### PR TITLE
feat: KaTeX rendering bridge + render_latex MCP tool

### DIFF
--- a/mcp-server/src/PenpotMcpServer.ts
+++ b/mcp-server/src/PenpotMcpServer.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorage } from "async_hooks";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { ExecuteCodeTool } from "./tools/ExecuteCodeTool";
+import { RenderLatexTool } from "./tools/RenderLatexTool";
 import { PluginBridge } from "./PluginBridge";
 import { ConfigurationLoader } from "./ConfigurationLoader";
 import { createLogger } from "./logger";
@@ -128,6 +129,7 @@ export class PenpotMcpServer {
         // Create relevant tool instances (depending on file system access)
         const toolInstances: Tool<any>[] = [
             new ExecuteCodeTool(this),
+            new RenderLatexTool(this),
             new HighLevelOverviewTool(this),
             new PenpotApiInfoTool(this, this.apiDocs),
             new ExportShapeTool(this), // tool adapts to file system access internally

--- a/mcp-server/src/tools/RenderLatexTool.ts
+++ b/mcp-server/src/tools/RenderLatexTool.ts
@@ -1,0 +1,123 @@
+import { z } from "zod";
+import { Tool } from "../Tool";
+import type { ToolResponse } from "../ToolResponse";
+import { TextResponse } from "../ToolResponse";
+import "reflect-metadata";
+import { PenpotMcpServer } from "../PenpotMcpServer";
+import { ExecuteCodePluginTask } from "../tasks/ExecuteCodePluginTask";
+import { ExecuteCodeTaskParams } from "@penpot-mcp/common";
+
+/**
+ * Arguments for the render_latex tool.
+ */
+export class RenderLatexArgs {
+    static schema = {
+        tex: z
+            .string()
+            .min(1, "tex cannot be empty")
+            .describe(
+                "LaTeX expression to render (e.g. '\\\\lim_{x \\\\to a} f(x) = L'). " +
+                    "Use '\\\\text{한글}' to mix Hangul with math; Hangul glyphs auto-fall-back " +
+                    "to Noto Sans KR, math/Greek glyphs use STIX Two Text."
+            ),
+        x: z
+            .number()
+            .default(0)
+            .describe("x offset inside the parent board (px). Default 0."),
+        y: z
+            .number()
+            .default(0)
+            .describe("y offset inside the parent board (px). Default 0."),
+        fontSize: z
+            .number()
+            .default(22)
+            .describe("Base font size in px. Default 22."),
+        color: z
+            .string()
+            .default("#1f2229")
+            .describe("Ink color (hex). Default #1f2229."),
+        display: z
+            .boolean()
+            .default(true)
+            .describe("KaTeX display mode (true=block, false=inline). Default true."),
+        parentId: z
+            .string()
+            .optional()
+            .describe(
+                "ID of the parent board. If omitted, the first board on the current page is used. " +
+                    "Pass the special string 'selection' to use the currently selected board."
+            ),
+    };
+
+    tex!: string;
+    x: number = 0;
+    y: number = 0;
+    fontSize: number = 22;
+    color: string = "#1f2229";
+    display: boolean = true;
+    parentId?: string;
+}
+
+/**
+ * Renders a LaTeX expression as a group of Penpot text nodes inside a board.
+ *
+ * Internally delegates to the plugin-side `latex(tex, opts)` helper installed
+ * by `ExecuteCodeTaskHandler`. The helper routes rendering to the UI iframe
+ * (KaTeX HTML + per-glyph layout measurement) and creates one text node per
+ * glyph in the plugin sandbox.
+ */
+export class RenderLatexTool extends Tool<RenderLatexArgs> {
+    constructor(mcpServer: PenpotMcpServer) {
+        super(mcpServer, RenderLatexArgs.schema);
+    }
+
+    public getToolName(): string {
+        return "render_latex";
+    }
+
+    public getToolDescription(): string {
+        return (
+            "Renders a LaTeX expression as a group of Penpot text nodes inside a board.\n" +
+            "Each glyph (lim, x, →, a, f, (, x, ), =, L, etc.) becomes a separate text node " +
+            "positioned by KaTeX layout. Math/Greek/operators use STIX Two Text; Hangul uses " +
+            "Noto Sans KR (auto-detected per glyph).\n" +
+            "Use this for: equation boxes in study material, inline math captions, formula labels.\n" +
+            "Returns the IDs and count of created glyph text nodes.\n" +
+            "If parentId is omitted, the first board on the current page is used."
+        );
+    }
+
+    protected async executeCore(args: RenderLatexArgs): Promise<ToolResponse> {
+        const parentLookup = args.parentId
+            ? args.parentId === "selection"
+                ? "penpot.selection.find(s=>s.type==='board')||penpot.currentPage.root.children.find(c=>c.type==='board')"
+                : `penpot.currentPage.root.children.find(c=>c.id===${JSON.stringify(args.parentId)})`
+            : "penpot.currentPage.root.children.find(c=>c.type==='board')";
+
+        const code = `
+            const parent = ${parentLookup};
+            if (!parent) { return { error: "No suitable parent board found" }; }
+            const eqs = await latex(${JSON.stringify(args.tex)}, {
+                x: ${args.x},
+                y: ${args.y},
+                fontSize: ${args.fontSize},
+                color: ${JSON.stringify(args.color)},
+                display: ${args.display},
+                parent,
+            });
+            return {
+                count: eqs.length,
+                parentId: parent.id,
+                parentName: parent.name,
+                ids: eqs.map(t => t.id),
+            };
+        `;
+
+        const task = new ExecuteCodePluginTask({ code } as ExecuteCodeTaskParams);
+        const result = await this.mcpServer.pluginBridge.executePluginTask(task);
+        if (result.data !== undefined) {
+            return new TextResponse(JSON.stringify(result.data, null, 2));
+        }
+        return new TextResponse("render_latex executed with no return value.");
+    }
+}

--- a/penpot-plugin/package-lock.json
+++ b/penpot-plugin/package-lock.json
@@ -11,6 +11,7 @@
                 "@penpot-mcp/common": "file:../common",
                 "@penpot/plugin-styles": "1.4.1",
                 "@penpot/plugin-types": "1.4.1",
+                "katex": "^0.16.45",
                 "penpot-mcp": "file:.."
             },
             "devDependencies": {
@@ -986,6 +987,31 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/katex": {
+            "version": "0.16.45",
+            "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+            "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+            "funding": [
+                "https://opencollective.com/katex",
+                "https://github.com/sponsors/katex"
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^8.3.0"
+            },
+            "bin": {
+                "katex": "cli.js"
+            }
+        },
+        "node_modules/katex/node_modules/commander": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
         },
         "node_modules/ms": {
             "version": "2.1.2",

--- a/penpot-plugin/package.json
+++ b/penpot-plugin/package.json
@@ -7,12 +7,14 @@
         "dev": "vite build --watch",
         "dev:multi-user": "cross-env MULTI_USER_MODE=true vite build --watch",
         "build": "tsc && vite build",
+        "postbuild": "node scripts/postbuild.mjs",
         "build:multi-user": "tsc && cross-env MULTI_USER_MODE=true vite build"
     },
     "dependencies": {
         "@penpot-mcp/common": "file:../common",
         "@penpot/plugin-styles": "1.4.1",
         "@penpot/plugin-types": "1.4.1",
+        "katex": "^0.16.45",
         "penpot-mcp": "file:.."
     },
     "devDependencies": {

--- a/penpot-plugin/public/manifest.json
+++ b/penpot-plugin/public/manifest.json
@@ -1,6 +1,15 @@
 {
     "name": "Penpot MCP Plugin",
-    "code": "plugin.js",
+    "code": "plugin-v15.js",
+    "icon": "icon.jpg",
+    "version": 2,
     "description": "This plugin enables interaction with the Penpot MCP server",
-    "permissions": ["content:read", "content:write", "library:read", "library:write", "comment:read", "comment:write"]
+    "permissions": [
+        "content:read",
+        "content:write",
+        "library:read",
+        "library:write",
+        "comment:read",
+        "comment:write"
+    ]
 }

--- a/penpot-plugin/scripts/postbuild.mjs
+++ b/penpot-plugin/scripts/postbuild.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// Post-build: rewrite dist/manifest.json's `code` field to point at the hashed
+// plugin entry (plugin-<hash>.js produced by vite). Also sync everything into
+// the running Penpot frontend container so the new code is served immediately.
+
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const dist = resolve(import.meta.dirname, "..", "dist");
+const files = readdirSync(dist);
+const pluginEntry = files.find((f) => /^plugin-[A-Za-z0-9_-]+\.js$/.test(f));
+if (!pluginEntry) {
+    console.error("postbuild: no plugin-<hash>.js found in dist/");
+    process.exit(1);
+}
+
+const manifestPath = resolve(dist, "manifest.json");
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+manifest.code = pluginEntry;
+writeFileSync(manifestPath, JSON.stringify(manifest, null, 4) + "\n");
+console.log("postbuild: manifest.code =", pluginEntry);
+
+// Sync into container
+const container = "penpot-penpot-frontend-1";
+const dest = "/var/www/app/plugins/mcp";
+for (const f of ["manifest.json", "index.html", "index.js", pluginEntry]) {
+    execSync(`docker cp ${resolve(dist, f)} ${container}:${dest}/${f}`, { stdio: "inherit" });
+}
+// Sync assets dir
+execSync(`docker cp ${resolve(dist, "assets")} ${container}:${dest}/`, { stdio: "inherit" });
+
+// Patch Penpot DB so the installed plugin record points at the new entry.
+// Pipe SQL via stdin to dodge shell quoting hell.
+const sql = `UPDATE profile SET props = jsonb_set(props::jsonb, '{~:plugins,~:data,342a3fe3-7634-80a4-8008-030592bd85fb,~:code}', '"${pluginEntry}"'::jsonb)::text::json WHERE email='zeskywa499@gmail.com';`;
+execSync("docker exec -i penpot-penpot-postgres-1 psql -U penpot -d penpot", {
+    input: sql,
+    stdio: ["pipe", "inherit", "inherit"],
+});
+
+console.log("postbuild: DB code field updated to", pluginEntry);

--- a/penpot-plugin/src/LatexBridge.ts
+++ b/penpot-plugin/src/LatexBridge.ts
@@ -1,0 +1,59 @@
+/**
+ * Bridge for LaTeX rendering requests.
+ *
+ * The Penpot plugin sandbox has no DOM, so KaTeX (which needs document/window for
+ * layout measurement) cannot run there. We route render requests to the plugin UI
+ * iframe (main.ts), which renders KaTeX and replies with measured glyphs.
+ *
+ * Wire-up:
+ *   plugin sandbox  ──[penpot.ui.sendMessage {type:"latex-render", requestId, ...}]──>  UI iframe
+ *   UI iframe       ──[parent.postMessage   {type:"latex-render-response", requestId,...}]──>  plugin sandbox
+ *
+ * On the plugin side, `penpot.ui.onMessage` is the single message entry — the bridge
+ * exposes `handleLatexResponse` so the existing onMessage handler can short-circuit
+ * latex responses without disturbing task-request routing.
+ */
+
+export interface LatexGlyph {
+    text: string;
+    x: number;
+    y: number;
+    fontSize: number;
+    italic: boolean;
+}
+
+export interface LatexRenderResponse {
+    type: "latex-render-response";
+    requestId: string;
+    glyphs?: LatexGlyph[];
+    width?: number;
+    height?: number;
+    error?: string;
+}
+
+let _counter = 0;
+const pending = new Map<string, (resp: LatexRenderResponse) => void>();
+
+export function nextRequestId(): string {
+    return "latex-" + (++_counter) + "-" + Date.now();
+}
+
+export function registerPending(id: string, cb: (resp: LatexRenderResponse) => void): void {
+    pending.set(id, cb);
+}
+
+/**
+ * If the incoming UI message is a latex render response, dispatch to the waiting
+ * resolver and return true (consumed). Otherwise return false so the caller can
+ * continue normal routing.
+ */
+export function handleLatexResponse(message: any): boolean {
+    if (!message || typeof message !== "object") return false;
+    if (message.type !== "latex-render-response") return false;
+    const cb = pending.get(message.requestId);
+    if (cb) {
+        pending.delete(message.requestId);
+        cb(message as LatexRenderResponse);
+    }
+    return true;
+}

--- a/penpot-plugin/src/katex.d.ts
+++ b/penpot-plugin/src/katex.d.ts
@@ -1,0 +1,2 @@
+declare module "katex/dist/katex.mjs";
+declare module "katex";

--- a/penpot-plugin/src/main.ts
+++ b/penpot-plugin/src/main.ts
@@ -1,4 +1,6 @@
 import "./style.css";
+import katex from "katex/dist/katex.mjs";
+import "katex/dist/katex.min.css";
 
 // get the current theme from the URL
 const searchParams = new URLSearchParams(window.location.search);
@@ -11,6 +13,44 @@ console.log("Penpot MCP multi-user mode:", isMultiUserMode);
 // WebSocket connection management
 let ws: WebSocket | null = null;
 const statusElement = document.getElementById("connection-status");
+
+// Keepalive / auto-reconnect state
+let keepaliveTimer: number | null = null;
+let reconnectTimer: number | null = null;
+let userClosed = false;  // true if user intentionally closed; auto-reconnect skipped
+const KEEPALIVE_INTERVAL_MS = 25_000;   // < 90s plugin-side idle threshold
+const RECONNECT_DELAY_MS = 3_000;
+
+function stopKeepalive(): void {
+    if (keepaliveTimer !== null) {
+        clearInterval(keepaliveTimer);
+        keepaliveTimer = null;
+    }
+}
+
+function startKeepalive(): void {
+    stopKeepalive();
+    keepaliveTimer = window.setInterval(() => {
+        if (ws && ws.readyState === WebSocket.OPEN) {
+            try {
+                // Application-level ping; server ignores unknown id.
+                ws.send(JSON.stringify({ __keepalive: true, ts: Date.now() }));
+            } catch (e) {
+                console.warn("keepalive send failed:", e);
+            }
+        }
+    }, KEEPALIVE_INTERVAL_MS);
+}
+
+function scheduleReconnect(): void {
+    if (userClosed) return;
+    if (reconnectTimer !== null) return;
+    reconnectTimer = window.setTimeout(() => {
+        reconnectTimer = null;
+        console.log("Auto-reconnecting to MCP server…");
+        connectToMcpServer();
+    }, RECONNECT_DELAY_MS);
+}
 
 /**
  * Updates the connection status display element.
@@ -63,6 +103,8 @@ function connectToMcpServer(): void {
         ws.onopen = () => {
             console.log("Connected to MCP server");
             updateConnectionStatus("Connected to MCP server", true);
+            userClosed = false;
+            startKeepalive();
         };
 
         ws.onmessage = (event) => {
@@ -77,10 +119,12 @@ function connectToMcpServer(): void {
         };
 
         ws.onclose = (event: CloseEvent) => {
-            console.log("Disconnected from MCP server");
+            console.log("Disconnected from MCP server (code=" + event.code + ")");
             const message = event.reason || undefined;
-            updateConnectionStatus("Disconnected", false, message);
+            updateConnectionStatus(userClosed ? "Disconnected" : "Reconnecting…", false, message);
             ws = null;
+            stopKeepalive();
+            scheduleReconnect();
         };
 
         ws.onerror = (error) => {
@@ -101,10 +145,116 @@ document.querySelector("[data-handler='connect-mcp']")?.addEventListener("click"
 
 // Listen plugin.ts messages
 window.addEventListener("message", (event) => {
-    if (event.data.source === "penpot") {
-        document.body.dataset.theme = event.data.theme;
-    } else if (event.data.type === "task-response") {
+    const data = event.data;
+    if (!data || typeof data !== "object") return;
+    if (data.source === "penpot") {
+        document.body.dataset.theme = data.theme;
+    } else if (data.type === "task-response") {
         // Forward task response back to MCP server
-        sendTaskResponse(event.data.response);
+        sendTaskResponse(data.response);
+    } else if (data.type === "latex-render") {
+        handleLatexRender(data).catch((err) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.error("latex-render error:", msg);
+            parent.postMessage(
+                { type: "latex-render-response", requestId: data.requestId, error: msg },
+                "*",
+            );
+        });
     }
 });
+
+// ---- LaTeX rendering bridge (server side) ---------------------------------
+//
+// The plugin sandbox has no DOM, so we render KaTeX here (UI iframe) and reply
+// with measured glyphs that the plugin can turn into Penpot text nodes.
+
+let _katexFontsReady = false;
+
+async function ensureKatexFonts(): Promise<void> {
+    if (_katexFontsReady) return;
+    try {
+        await (document as any).fonts?.ready;
+    } catch (_e) {
+        // ignore — fall through with whatever metrics the browser has
+    }
+    _katexFontsReady = true;
+}
+
+async function handleLatexRender(req: {
+    requestId: string;
+    tex: string;
+    opts?: { fontSize?: number; display?: boolean };
+}): Promise<void> {
+    await ensureKatexFonts();
+    const fontSize = req.opts?.fontSize ?? 16;
+    const display = req.opts?.display !== false;
+
+    let html: string;
+    try {
+        html = (katex as any).renderToString(req.tex, {
+            displayMode: display,
+            throwOnError: false,
+            output: "html",
+        });
+    } catch (e: any) {
+        parent.postMessage(
+            {
+                type: "latex-render-response",
+                requestId: req.requestId,
+                error: `KaTeX render failed: ${e?.message ?? String(e)}`,
+            },
+            "*",
+        );
+        return;
+    }
+
+    const tmp = document.createElement("div");
+    tmp.style.cssText =
+        `position:absolute;left:-9999px;top:-9999px;font-size:${fontSize}px;visibility:hidden;`;
+    tmp.innerHTML = html;
+    document.body.appendChild(tmp);
+
+    // Force layout by reading bounds.
+    const baseRect = tmp.getBoundingClientRect();
+
+    const glyphs: Array<{ text: string; x: number; y: number; fontSize: number; italic: boolean }> = [];
+
+    const walk = (node: Element): void => {
+        if (node.children.length === 0) {
+            const txt = node.textContent ?? "";
+            if (txt.trim().length > 0) {
+                const rect = node.getBoundingClientRect();
+                const cs = window.getComputedStyle(node);
+                const sz = parseFloat(cs.fontSize) || fontSize;
+                const ff = cs.fontFamily || "";
+                const italic = cs.fontStyle === "italic" || ff.includes("KaTeX_Math");
+                glyphs.push({
+                    text: txt,
+                    x: rect.left - baseRect.left,
+                    y: rect.top - baseRect.top,
+                    fontSize: sz,
+                    italic,
+                });
+            }
+        } else {
+            for (const c of Array.from(node.children)) walk(c as Element);
+        }
+    };
+
+    if (tmp.firstElementChild) walk(tmp.firstElementChild);
+
+    const finalRect = tmp.getBoundingClientRect();
+    document.body.removeChild(tmp);
+
+    parent.postMessage(
+        {
+            type: "latex-render-response",
+            requestId: req.requestId,
+            glyphs,
+            width: finalRect.width,
+            height: finalRect.height,
+        },
+        "*",
+    );
+}

--- a/penpot-plugin/src/plugin.ts
+++ b/penpot-plugin/src/plugin.ts
@@ -1,5 +1,6 @@
 import { ExecuteCodeTaskHandler } from "./task-handlers/ExecuteCodeTaskHandler";
 import { Task, TaskHandler } from "./TaskHandler";
+import { handleLatexResponse } from "./LatexBridge";
 
 /**
  * Registry of all available task handlers.
@@ -14,9 +15,12 @@ const isMultiUserMode = typeof IS_MULTI_USER_MODE !== "undefined" ? IS_MULTI_USE
 penpot.ui.open("Penpot MCP Plugin", `?theme=${penpot.theme}&multiUser=${isMultiUserMode}`, { width: 300, height: 250 });
 
 // Handle messages
-penpot.ui.onMessage<string | { id: string; task: string; params: any }>((message) => {
+penpot.ui.onMessage<any>((message) => {
+    // LatexBridge consumes its own responses first; if it handled the message, stop.
+    if (handleLatexResponse(message)) return;
+
     // Handle plugin task requests
-    if (typeof message === "object" && message.task && message.id) {
+    if (typeof message === "object" && message && message.task && message.id) {
         handlePluginTaskRequest(message).catch((error) => {
             console.error("Error in handlePluginTaskRequest:", error);
         });

--- a/penpot-plugin/src/task-handlers/ExecuteCodeTaskHandler.ts
+++ b/penpot-plugin/src/task-handlers/ExecuteCodeTaskHandler.ts
@@ -1,6 +1,9 @@
 import { Task, TaskHandler } from "../TaskHandler";
 import { ExecuteCodeTaskParams, ExecuteCodeTaskResultData } from "../../../common/src";
 import { PenpotUtils } from "../PenpotUtils.ts";
+import { nextRequestId, registerPending, LatexGlyph, LatexRenderResponse } from "../LatexBridge";
+
+const LATEX_TIMEOUT_MS = 30_000;
 
 /**
  * Console implementation that captures all log output for code execution.
@@ -175,12 +178,81 @@ export class ExecuteCodeTaskHandler extends TaskHandler<ExecuteCodeTaskParams> {
     constructor() {
         super();
 
-        // initialize context, making penpot, penpotUtils, storage and the custom console available
+        // initialize context, making penpot, penpotUtils, storage, console, and latex helper available
+        //
+        // The plugin sandbox has no DOM; latex rendering is routed to the UI iframe
+        // (see LatexBridge + main.ts handleLatexRender). The helper is async — callers
+        // must `await latex(...)`.
+        const latex = async (tex: string, opts: any = {}): Promise<any[]> => {
+            const fontSize: number = typeof opts.fontSize === "number" ? opts.fontSize : 16;
+            const xBase: number = typeof opts.x === "number" ? opts.x : 0;
+            const yBase: number = typeof opts.y === "number" ? opts.y : 0;
+            const inkColor: string = opts.color || "#1f2229";
+            const parent = opts.parent || null;
+            const display: boolean = opts.display !== false;
+
+            const requestId = nextRequestId();
+            const resp: LatexRenderResponse = await new Promise((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    reject(new Error(`latex render timed out after ${LATEX_TIMEOUT_MS}ms`));
+                }, LATEX_TIMEOUT_MS);
+                registerPending(requestId, (r) => {
+                    clearTimeout(timer);
+                    resolve(r);
+                });
+                penpot.ui.sendMessage({
+                    type: "latex-render",
+                    requestId,
+                    tex,
+                    opts: { fontSize, display },
+                });
+            });
+
+            if (resp.error) {
+                throw new Error(resp.error);
+            }
+
+            const glyphs: LatexGlyph[] = resp.glyphs ?? [];
+            const created: any[] = [];
+            // t.x / t.y are page absolute coordinates. If a board parent is given,
+            // its (page x, page y) must be added so glyphs land *inside* the board.
+            const xOff = (parent && parent.type === "board") ? parent.x : 0;
+            const yOff = (parent && parent.type === "board") ? parent.y : 0;
+            // Korean glyphs need a Hangul font; math/Greek/Latin need a math-capable font.
+            // STIX Two Text covers Greek + math operators (Σ α ∫ → …). Hangul falls back
+            // to Noto Sans KR. Detected per-glyph.
+            const hangul = /[ᄀ-ᇿ㄰-㆏가-힯]/;
+            for (const g of glyphs) {
+                const t = (penpot as any).createText(g.text);
+                if (!t) continue;
+                t.growType = "auto-width";
+                if (hangul.test(g.text)) {
+                    t.fontId = "gfont-noto-sans-kr";
+                    t.fontFamily = "Noto Sans KR";
+                } else {
+                    t.fontId = "gfont-stix-two-text";
+                    t.fontFamily = "STIX Two Text";
+                }
+                t.fontVariantId = "regular";
+                t.fontWeight = "400";
+                t.fontSize = String(Math.round(g.fontSize));
+                t.fills = [{ fillColor: inkColor, fillOpacity: 1 }];
+                t.x = xOff + xBase + g.x;
+                t.y = yOff + yBase + g.y;
+                if (parent && typeof parent.appendChild === "function") {
+                    parent.appendChild(t);
+                }
+                created.push(t);
+            }
+            return created;
+        };
+
         this.context = {
             penpot: penpot,
             storage: {},
             console: new ExecuteCodeTaskConsole(),
             penpotUtils: PenpotUtils,
+            latex,
         };
     }
 

--- a/penpot-plugin/vite.config.ts
+++ b/penpot-plugin/vite.config.ts
@@ -11,6 +11,7 @@ const websocketUrl = `ws://${serverAddress}:${websocketPort}`;
 console.log("Will define PENPOT_MCP_WEBSOCKET_URL as:", JSON.stringify(websocketUrl));
 
 export default defineConfig({
+    base: "./",
     plugins: [
         livePreview({
             reload: true,
@@ -28,7 +29,8 @@ export default defineConfig({
                 index: "./index.html",
             },
             output: {
-                entryFileNames: "[name].js",
+                entryFileNames: (chunk) =>
+                    chunk.name === "plugin" ? "plugin-[hash].js" : "[name].js",
             },
         },
     },
@@ -38,6 +40,11 @@ export default defineConfig({
         allowedHosts: process.env.PENPOT_MCP_PLUGIN_SERVER_LISTEN_ADDRESS
             ? process.env.PENPOT_MCP_PLUGIN_SERVER_LISTEN_ADDRESS.split(",").map((h) => h.trim())
             : [],
+        headers: {
+            "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+            "Pragma": "no-cache",
+            "Expires": "0",
+        },
     },
     define: {
         IS_MULTI_USER_MODE: JSON.stringify(process.env.MULTI_USER_MODE === "true"),

--- a/scripts/open-plugin.mjs
+++ b/scripts/open-plugin.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+// Headless Penpot driver — login via the RPC API (skips brittle React form
+// discovery), inject auth cookie into Playwright context, open the file
+// workspace, then launch the MCP plugin panel.
+//
+// Required env:  PENPOT_EMAIL, PENPOT_PASSWORD
+// Optional env:  PENPOT_BASE_URL (default http://localhost:9001)
+//                PENPOT_FILE_ID  workspace target
+//                HEADLESS=0 to run headed (needs WSLg/X)
+//                KEEP_OPEN=0 to exit after :4402 confirmation
+//
+// Prints "READY :4402 connected" on success.
+
+import { chromium } from "playwright";
+import { execSync } from "node:child_process";
+
+const BASE = process.env.PENPOT_BASE_URL || "http://localhost:9001";
+const EMAIL = process.env.PENPOT_EMAIL;
+const PASSWORD = process.env.PENPOT_PASSWORD;
+const FILE_ID = process.env.PENPOT_FILE_ID;
+const TEAM_ID = process.env.PENPOT_TEAM_ID;
+const PAGE_ID = process.env.PENPOT_PAGE_ID;
+const HEADLESS = process.env.HEADLESS !== "0";
+const KEEP_OPEN = process.env.KEEP_OPEN !== "0";
+
+if (!EMAIL || !PASSWORD) {
+    console.error("PENPOT_EMAIL and PENPOT_PASSWORD must be set");
+    process.exit(2);
+}
+
+function pluginClientCount() {
+    try {
+        const out = execSync("ss -tn state established 'sport = :4402'", { encoding: "utf8" });
+        return out.trim().split("\n").length - 1;
+    } catch { return 0; }
+}
+
+async function loginAndGetCookie() {
+    const url = BASE + "/api/rpc/command/login-with-password";
+    const body = JSON.stringify({ "~:email": EMAIL, "~:password": PASSWORD });
+    const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+    });
+    if (!res.ok) throw new Error(`login failed: ${res.status} ${await res.text()}`);
+    const setCookie = res.headers.get("set-cookie");
+    if (!setCookie) throw new Error("no Set-Cookie in login response");
+    // Set-Cookie: auth-token=...; Path=/; HttpOnly; Expires=...
+    const m = setCookie.match(/auth-token=([^;]+)/);
+    if (!m) throw new Error("auth-token cookie not found");
+    return m[1];
+}
+
+async function main() {
+    console.error("[open-plugin] login via RPC");
+    const authToken = await loginAndGetCookie();
+    console.error("[open-plugin] auth-token len=" + authToken.length);
+
+    console.error("[open-plugin] launching chromium (headless=" + HEADLESS + ")");
+    const browser = await chromium.launch({ headless: HEADLESS, args: ["--no-sandbox"] });
+    const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    await ctx.addCookies([{
+        name: "auth-token",
+        value: authToken,
+        domain: "localhost",
+        path: "/",
+        httpOnly: true,
+        secure: false,
+        sameSite: "Lax",
+    }]);
+
+    const page = await ctx.newPage();
+    page.on("pageerror", (e) => console.error("[pageerror]", e.message.slice(0, 200)));
+    page.on("console", (msg) => {
+        const t = msg.text();
+        if (/MCP|plugin|websocket|katex|latex/i.test(t) || msg.type() === "error") {
+            console.error("[console:" + msg.type() + "]", t.slice(0, 200));
+        }
+    });
+
+    let target;
+    if (FILE_ID && TEAM_ID) {
+        const parts = [`team-id=${TEAM_ID}`, `file-id=${FILE_ID}`];
+        if (PAGE_ID) parts.push(`page-id=${PAGE_ID}`);
+        target = `${BASE}/#/workspace?${parts.join("&")}`;
+    } else {
+        target = `${BASE}/#/dashboard`;
+    }
+    console.error("[open-plugin] navigating", target);
+    await page.goto(target, { waitUntil: "domcontentloaded", timeout: 30000 });
+    await page.waitForLoadState("networkidle", { timeout: 30000 }).catch(() => {});
+    await page.waitForTimeout(3000);
+
+    // Open Plugin Manager: Ctrl+Alt+P
+    console.error("[open-plugin] Ctrl+Alt+P");
+    await page.keyboard.press("Control+Alt+P");
+    await page.waitForTimeout(1500);
+
+    // Click on the installed "Penpot MCP Plugin" — Penpot Hub shows installed
+    // plugins as cards. Selector tries a few common shapes.
+    // The Plugin Manager modal lists installed plugins. We want to click the
+    // Open button on the "Penpot MCP Plugin" card. The DOM structure isn't
+    // documented; we probe several selectors and fall back to text+sibling.
+    let clicked = false;
+    const tryClick = async (loc, label) => {
+        try {
+            if (await loc.isVisible({ timeout: 1500 }).catch(() => false)) {
+                console.error("[open-plugin] clicking:", label);
+                await loc.click({ timeout: 3000 });
+                return true;
+            }
+        } catch (e) { console.error("[open-plugin] click failed for", label, e.message); }
+        return false;
+    };
+
+    // Strategy 1: xpath — find any element whose own text contains "Penpot MCP Plugin"
+    // and that has a descendant <button> with text "Open"
+    const xp1 = page.locator(
+        "xpath=//*[contains(normalize-space(.),'Penpot MCP Plugin')][.//button[normalize-space()='Open']][1]//button[normalize-space()='Open']"
+    ).first();
+    clicked = await tryClick(xp1, "xpath card-with-Open");
+
+    // Strategy 2: each "Open" button — pick the one whose surrounding text mentions our plugin
+    if (!clicked) {
+        const allOpen = await page.locator("button", { hasText: /^Open$/ }).all();
+        for (let i = 0; i < allOpen.length; i++) {
+            const btn = allOpen[i];
+            const parent = btn.locator("xpath=ancestor::*[self::div or self::li or self::article][1]");
+            const txt = (await parent.textContent().catch(() => "")) || "";
+            if (txt.includes("Penpot MCP")) {
+                clicked = await tryClick(btn, `Open #${i} (parent text matches)`);
+                if (clicked) break;
+            }
+        }
+    }
+
+    // Strategy 3: only one Open button visible (installed plugin list shows just our one)
+    if (!clicked) {
+        const all = page.getByRole("button", { name: /^Open$/ });
+        const n = await all.count().catch(() => 0);
+        if (n === 1) clicked = await tryClick(all.first(), "sole Open button");
+    }
+
+    if (!clicked) console.error("[open-plugin] could not find Open button via any strategy");
+
+    // After Open, plugin iframe loads. It contains a "Connect to MCP server"
+    // button that the user must click before WebSocket connects. Do that
+    // automatically — find the plugin iframe and click [data-handler='connect-mcp'].
+    if (clicked) {
+        console.error("[open-plugin] waiting for plugin iframe to appear");
+        const iframeLoc = page.frameLocator("iframe[src*='/plugins/mcp/']");
+        // Iframe load can take a couple seconds
+        await page.waitForTimeout(2000);
+        const connectBtn = iframeLoc.locator("[data-handler='connect-mcp']");
+        try {
+            await connectBtn.waitFor({ state: "visible", timeout: 8000 });
+            console.error("[open-plugin] clicking 'Connect to MCP server' inside plugin iframe");
+            await connectBtn.click();
+        } catch (e) {
+            console.error("[open-plugin] connect button not found in iframe:", e.message.slice(0, 200));
+        }
+    }
+
+    // Wait up to 30s for plugin sandbox to connect to :4402.
+    const t0 = Date.now();
+    let n = 0;
+    while (Date.now() - t0 < 30000) {
+        n = pluginClientCount();
+        if (n > 0) break;
+        await page.waitForTimeout(1000);
+    }
+
+    if (n > 0) {
+        console.log("READY :4402 connected (" + n + " client" + (n > 1 ? "s" : "") + ")");
+    } else {
+        console.error("[open-plugin] FAILED — no :4402 client after 30s");
+        await page.screenshot({ path: "/tmp/penpot.png", fullPage: true }).catch(() => {});
+        // Dump every visible button + dialog text
+        const buttons = await page.locator("button, [role='button']").allTextContents().catch(() => []);
+        console.error("buttons (" + buttons.length + "):", buttons.slice(0, 40).map(s => s.trim()).filter(Boolean));
+        const dialogs = await page.locator("dialog, [role='dialog']").count().catch(() => 0);
+        console.error("dialog count:", dialogs);
+        if (dialogs > 0) {
+            const dt = await page.locator("dialog, [role='dialog']").first().textContent().catch(() => "");
+            console.error("dialog text head:", (dt || "").slice(0, 800));
+        }
+        // Also scan for any element containing "MCP" text
+        const mcpEls = await page.locator(":has-text('Penpot MCP')").count().catch(() => 0);
+        console.error("elements containing 'Penpot MCP':", mcpEls);
+        if (!KEEP_OPEN) { await browser.close(); process.exit(3); }
+    }
+
+    if (KEEP_OPEN) {
+        console.error("[open-plugin] parking (set KEEP_OPEN=0 to exit)");
+        await new Promise(() => {});
+    } else {
+        await browser.close();
+    }
+}
+
+main().catch((e) => { console.error("[open-plugin] fatal:", e?.stack ?? e); process.exit(1); });

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,132 @@
+{
+  "name": "scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "scripts",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "mathjax-full": "^3.2.1",
+        "playwright": "^1.60.0"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/mathjax-full": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.1.tgz",
+      "integrity": "sha512-aUz9o16MGZdeiIBwZjAfUBTiJb7LRqzZEl1YOZ8zQMGYIyh1/nxRebxKxjDe9L+xcZCr2OHdzoFBMcd6VnLv9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
+      }
+    },
+    "node_modules/mhchemparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
+      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/speech-rule-engine": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.4.tgz",
+      "integrity": "sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xmldom/xmldom": "0.9.10",
+        "commander": "13.1.0",
+        "wicked-good-xpath": "1.3.0"
+      },
+      "bin": {
+        "sre": "bin/sre"
+      }
+    },
+    "node_modules/wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "scripts",
+  "version": "1.0.0",
+  "description": "",
+  "main": "tex2html.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "mathjax-full": "^3.2.1",
+    "playwright": "^1.60.0"
+  }
+}

--- a/scripts/screenshot-board.mjs
+++ b/scripts/screenshot-board.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Take a fresh viewport screenshot of the current Penpot workspace.
+// Logs in via RPC, opens the file, zooms to fit the board, screenshots.
+
+import { chromium } from "playwright";
+
+const BASE = "http://localhost:9001";
+const EMAIL = process.env.PENPOT_EMAIL;
+const PASSWORD = process.env.PENPOT_PASSWORD;
+if (!EMAIL || !PASSWORD) {
+    console.error("PENPOT_EMAIL and PENPOT_PASSWORD must be set");
+    process.exit(2);
+}
+const TEAM = process.env.PENPOT_TEAM_ID;
+const FILE = process.env.PENPOT_FILE_ID;
+const PAGE = process.env.PENPOT_PAGE_ID;
+if (!TEAM || !FILE) {
+    console.error("PENPOT_TEAM_ID and PENPOT_FILE_ID must be set");
+    process.exit(2);
+}
+const OUT = process.argv[2] || "/tmp/penpot-board-shot.png";
+
+const res = await fetch(`${BASE}/api/rpc/command/login-with-password`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ "~:email": EMAIL, "~:password": PASSWORD }),
+});
+const tok = res.headers.get("set-cookie").match(/auth-token=([^;]+)/)[1];
+
+const browser = await chromium.launch({ headless: true, args: ["--no-sandbox"] });
+const ctx = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+await ctx.addCookies([
+    { name: "auth-token", value: tok, domain: "localhost", path: "/", httpOnly: true, secure: false, sameSite: "Lax" },
+]);
+const page = await ctx.newPage();
+await page.goto(`${BASE}/#/workspace?team-id=${TEAM}&file-id=${FILE}&page-id=${PAGE}`, { waitUntil: "domcontentloaded" });
+await page.waitForLoadState("networkidle", { timeout: 30000 }).catch(() => {});
+// Allow workspace canvas to render
+await page.waitForTimeout(5000);
+
+// Zoom to fit (Penpot keyboard shortcut: Shift+1)
+await page.keyboard.press("Shift+1");
+await page.waitForTimeout(1500);
+
+await page.screenshot({ path: OUT, fullPage: false });
+console.log(OUT);
+await browser.close();

--- a/scripts/tex2html.js
+++ b/scripts/tex2html.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * tex2html — render a LaTeX expression to a self-contained HTML snippet
+ * suitable for pasting into the Penpot HTML TO DESIGN plugin.
+ *
+ * Usage:
+ *   node tex2html.js "\\lim_{x \\to a} f(x) = L"
+ *   node tex2html.js "\\lim_{x \\to a} f(x) = L" --inline    # inline mode
+ *   node tex2html.js "\\lim_{x \\to a} f(x) = L" --size 22 --color "#1f2229"
+ *
+ * Stdout is the HTML — pipe to clipboard or paste manually.
+ *
+ * Notes on the HTML shape:
+ *   - KaTeX CSS is inlined (no external stylesheet needed).
+ *   - KaTeX font @font-face URLs still reference external woff2 files. HTML
+ *     TO DESIGN will not download those, so the math glyphs will fall back to
+ *     the browser's default math/serif font. The shape/layout still tracks
+ *     KaTeX (sub/superscripts, lim operator, etc.) — just without KaTeX's
+ *     custom glyph design.
+ *   - If you need pixel-perfect KaTeX glyphs, swap to SVG via MathJax later.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+// Resolve katex from the mcp-server install (already present).
+const katex = require(path.join(__dirname, "..", "penpot-plugin", "node_modules", "katex"));
+const cssPath = require.resolve("katex/dist/katex.min.css", {
+    paths: [path.join(__dirname, "..", "penpot-plugin", "node_modules")],
+});
+
+function parseArgs(argv) {
+    const args = { tex: null, display: true, size: 22, color: "#1f2229" };
+    const rest = [];
+    for (let i = 2; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === "--inline") { args.display = false; continue; }
+        if (a === "--display") { args.display = true; continue; }
+        if (a === "--size") { args.size = parseFloat(argv[++i]); continue; }
+        if (a === "--color") { args.color = argv[++i]; continue; }
+        rest.push(a);
+    }
+    args.tex = rest.join(" ");
+    return args;
+}
+
+function main() {
+    const args = parseArgs(process.argv);
+    if (!args.tex) {
+        console.error("usage: tex2html.js <LaTeX> [--inline] [--size N] [--color #hex]");
+        process.exit(1);
+    }
+
+    let html;
+    try {
+        html = katex.renderToString(args.tex, {
+            displayMode: args.display,
+            throwOnError: true,
+            output: "html",
+        });
+    } catch (e) {
+        console.error("KaTeX render failed:", e.message);
+        process.exit(2);
+    }
+
+    const css = fs.readFileSync(cssPath, "utf8");
+
+    // Self-contained snippet — inline <style> + the KaTeX HTML, wrapped in a
+    // sizing div. HTML TO DESIGN should accept the whole blob.
+    const out = `<style>${css}</style><div style="font-size:${args.size}px;color:${args.color};line-height:1.2;">${html}</div>`;
+
+    process.stdout.write(out);
+}
+
+main();

--- a/scripts/tex2svg.mjs
+++ b/scripts/tex2svg.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// tex2svg — render a LaTeX expression to a self-contained SVG (every glyph
+// is a path, no external font dependency). Suitable for Penpot drag&drop.
+//
+// Usage:
+//   node tex2svg.mjs "\\lim_{x \\to a} f(x) = L"
+//   node tex2svg.mjs "f(x) = x^2 + 2x + 1" --inline
+//   node tex2svg.mjs "..." --out /tmp/eq.svg --size 22 --color "#1f2229"
+//
+// Defaults: display mode, size 22px, color #1f2229, out /tmp/eq.svg
+
+import { mathjax } from "mathjax-full/js/mathjax.js";
+import { TeX } from "mathjax-full/js/input/tex.js";
+import { SVG } from "mathjax-full/js/output/svg.js";
+import { liteAdaptor } from "mathjax-full/js/adaptors/liteAdaptor.js";
+import { RegisterHTMLHandler } from "mathjax-full/js/handlers/html.js";
+import { AllPackages } from "mathjax-full/js/input/tex/AllPackages.js";
+import { writeFileSync } from "node:fs";
+
+function parseArgs(argv) {
+    const a = { tex: null, display: true, size: 22, color: "#1f2229", out: "/tmp/eq.svg" };
+    const rest = [];
+    for (let i = 2; i < argv.length; i++) {
+        const v = argv[i];
+        if (v === "--inline") a.display = false;
+        else if (v === "--display") a.display = true;
+        else if (v === "--size") a.size = parseFloat(argv[++i]);
+        else if (v === "--color") a.color = argv[++i];
+        else if (v === "--out") a.out = argv[++i];
+        else rest.push(v);
+    }
+    a.tex = rest.join(" ");
+    return a;
+}
+
+const args = parseArgs(process.argv);
+if (!args.tex) {
+    console.error("usage: tex2svg.mjs <LaTeX> [--inline] [--size N] [--color #hex] [--out path]");
+    process.exit(1);
+}
+
+const adaptor = liteAdaptor();
+RegisterHTMLHandler(adaptor);
+
+const tex = new TeX({ packages: AllPackages });
+// fontCache: 'none' inlines every glyph as <path> — no external <defs> or font fetch.
+const svg = new SVG({ fontCache: "none" });
+const html = mathjax.document("", { InputJax: tex, OutputJax: svg });
+
+const node = html.convert(args.tex, { display: args.display, em: args.size, ex: args.size / 2 });
+let out = adaptor.innerHTML(node);
+// adaptor wraps in <mjx-container>; strip it, keep the <svg>
+const svgMatch = out.match(/<svg[\s\S]*<\/svg>/);
+if (!svgMatch) {
+    console.error("no <svg> in mathjax output");
+    process.exit(2);
+}
+let s = svgMatch[0];
+// Force ink color
+s = s.replace(/<svg /, `<svg color="${args.color}" `);
+
+writeFileSync(args.out, s);
+console.error(`wrote ${args.out} (${s.length} bytes)`);
+console.log(args.out);


### PR DESCRIPTION
## Summary

- LaTeX expressions rendered as Penpot text nodes (per-glyph via KaTeX layout)
- `render_latex` MCP tool — `{tex, x, y, fontSize, color, display, parentId}`
- IPC bridge plugin sandbox ↔ UI iframe (sandbox has no DOM for KaTeX)
- Auto-handling of font fallback (STIX Two Text for math/Greek, Noto Sans KR for Hangul)
- Plugin: WebSocket keepalive + auto-reconnect; vite contenthash + postbuild auto-sync

## Test plan

- [x] `typeof latex === 'function'` in sandbox after plugin reload
- [x] `await latex("\\lim_{x \\to a} f(x) = L", {...})` creates 11 visible text nodes
- [x] Greek/math symbols (∑, α, ∫, →) render correctly via STIX Two Text
- [x] `render_latex` MCP tool invocation returns shape IDs
- [x] Playwright e2e: login → workspace → Ctrl+Alt+P → Open → Connect → :4402 ESTAB

Closes #[ISSUE]

🤖 Generated with [Claude Code](https://claude.com/claude-code)